### PR TITLE
Wait document ready to setup plugins

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -471,7 +471,9 @@ var Formstone = this.Formstone = (function ($, window, document, undefined) {
 
 	function setupPlugin(namespace) {
 		if (!Formstone.Plugins[namespace].initialized) {
-			Formstone.Plugins[namespace].methods._setup.call(document);
+            $(function() {
+                Formstone.Plugins[namespace].methods._setup.call(document);
+            });
 			Formstone.Plugins[namespace].initialized = true;
 		}
 	}

--- a/src/js/core.js
+++ b/src/js/core.js
@@ -471,9 +471,9 @@ var Formstone = this.Formstone = (function ($, window, document, undefined) {
 
 	function setupPlugin(namespace) {
 		if (!Formstone.Plugins[namespace].initialized) {
-            $(function() {
-                Formstone.Plugins[namespace].methods._setup.call(document);
-            });
+			$(function() {
+				Formstone.Plugins[namespace].methods._setup.call(document);
+			});
 			Formstone.Plugins[namespace].initialized = true;
 		}
 	}


### PR DESCRIPTION
I noticed that [here](https://github.com/pensiero/Formstone/blob/hotfix/wait-document-ready/src/js/core.js#L613) you setup `Formstone.$body`.

However, because the initialization is done [here](https://github.com/pensiero/Formstone/blob/hotfix/wait-document-ready/src/js/core.js#L472-L479), and this operation take place **before** the document ready, the plugins that uses the body can't find it (triggering an error that break everything).

I noticed that [here](https://github.com/pensiero/Formstone/blob/hotfix/wait-document-ready/src/js/core.js#L615-L619) you call the setup of each plugin again, but this setup it's not triggered because each plugin are already marked as `initialized`.

If you merge the PR, can you do the minified version of this file? I don't know how you did :)

Thanks
