### PR TITLE
Added cursor pointer for labels

### DIFF
--- a/src/less/checkbox.less
+++ b/src/less/checkbox.less
@@ -166,6 +166,7 @@
 			line-height: @fs-checkbox-marker-height-width;
 			overflow: hidden;
 			user-select: none;
+			cursor: pointer;
 		}
 
 		/**


### PR DESCRIPTION
So as empty space between checkbox & it's label would not seem as unclickable, whilst it is clickable and can be clicked to toggle checked checkbox.
