### PR TITLE
Label will not show when explicitly set to empty string.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+### 0.8.30
+* Upload Label will not show when Label property set to empty string. Initialized value unaffected.
 
 ### 0.8.29
 

--- a/src/js/upload.js
+++ b/src/js/upload.js
@@ -13,9 +13,12 @@
 		if (Formstone.support.file) {
 			var html = "";
 
-			html += '<div class="' + RawClasses.target + '">';
-			html += data.label;
-			html += '</div>';
+			if (data.label != "")
+			{
+				html += '<div class="' + RawClasses.target + '">';
+				html += data.label;
+				html += '</div>';
+			}
 			html += '<input class="' + RawClasses.input + '" type="file"';
 			if (data.multiple) {
 				html += ' multiple';

--- a/src/js/upload.js
+++ b/src/js/upload.js
@@ -13,7 +13,7 @@
 		if (Formstone.support.file) {
 			var html = "";
 
-			if (data.label != "")
+			if (data.label !== "")
 			{
 				html += '<div class="' + RawClasses.target + '">';
 				html += data.label;


### PR DESCRIPTION
In my example when a div containing an image becomes a placeholder to drag and drop a file with the purpose of updating the target image; That the Label appearing below is not needed. Especially when the class `fs-upload-dropping` is being used to indicate the drop zone, with a background highlight for example. To remove the label, set the property to empty string during usage initialisation.

`<div class="upload">`
`<img src="/Images/example.png" />`
`</div>`

(my first github change and pull request - feedback welcome)
