### PR TITLE
Add empty alt attribute to the image

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -199,7 +199,7 @@
 
 	function loadImage(data, source, poster, firstLoad) {
 		var imageClasses = [RawClasses.media, RawClasses.image, (firstLoad !== true ? RawClasses.animated : '')].join(" "),
-			$media = $('<div class="' + imageClasses + '"><img></div>'),
+			$media = $('<div class="' + imageClasses + '"><img alt=""></div>'),
 			$img = $media.find("img"),
 			newSource = source;
 


### PR DESCRIPTION
This inline image is really serving the purpose of a background image so I don't think we actually need to set content of the alt attribute but what do you think about adding an empty one here for validation?
