### PR TITLE
Updates open() function with return false

### DIFF
--- a/src/js/navigation.js
+++ b/src/js/navigation.js
@@ -184,6 +184,7 @@
 
 	function open(data) {
 		data.$handle.fsSwap("activate");
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
It is likely the user does not want to be scrolled to the top of the page when opening the menu. This is needed to enable that, and I'm unaware of side effects.