### PR TITLE
add youtube tracking url parameters

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -955,7 +955,8 @@
     function loadVideo(source) {
       var parts,
         url = checkVideo(source),
-        queryString = source.split("?");
+        queryString = source.split("?"),
+        origin = '&origin=' + encodeURIComponent(window.location.protocol + '//' + window.location.hostname);
 
       if (url) {
         // if we have a query string
@@ -966,7 +967,7 @@
         Instance.$videoWrapper = $('<div class="' + RawClasses.video_wrapper + '"></div>');
         Instance.$video = $('<iframe class="' + RawClasses.video + '" frameborder="0" seamless="seamless" allowfullscreen></iframe>');
 
-        Instance.$video.attr("src", url)
+        Instance.$video.attr("src", url + '&enablejsapi=1' + origin)
           .addClass(RawClasses.video)
           .prependTo(Instance.$videoWrapper);
 


### PR DESCRIPTION
Yo Ben!

I brought some code with me! ;)

This is something I added to Concordia College to _utilize the new youtube video tracking analytics for gtm to work with the formstone lightbox_. It enables the youtube api and adds in the required origin based on the site's url. Luckily this doesn't effect the rendering of the video.

The only requirement left to enable youtube video tracking via gtm is to add `<script src="https://www.youtube.com/iframe_api"></script>` to your site since the video is dynamically loaded (otherwise for plain embeds the script is unnecessary.

I just realized that vimeo could be passed in too >.>

Thank you!,
Bryan Stoner