### PR TITLE
Add EventListener object at Events.fileProgress params

### DIFF
--- a/src/js/upload.js
+++ b/src/js/upload.js
@@ -549,7 +549,7 @@
                     percent = Math.ceil((position / total) * 100);
                   }
 
-                  data.$el.trigger(Events.fileProgress, [file, percent]);
+                  data.$el.trigger(Events.fileProgress, [file, percent, e]);
                 }, false);
               }
 


### PR DESCRIPTION
Switching the object to the callback is necessary if you want to better customize the progress bar.
For example, with this data, you could create something like this

Uploaded 25.5M of 50MB (50.1%)

Note: GitHub changed the line spacing automatically. I only changed one line. To see the changes I made a diff without considering the white spaces.