### PR TITLE
Lightbox accessibility improvements

### DIFF
--- a/src/js/lightbox.js
+++ b/src/js/lightbox.js
@@ -1,26 +1,26 @@
 // import MediaQuery from './mediaquery.js';
 import {
-  extend,
-  //
-  element,
-  select,
-  siblings,
-  iterate,
-  //
-  on,
-  off,
-  once,
-  trigger,
-  //
-  addClass,
-  removeClass,
-  hasClass,
-  //
-  getAttr,
-  setAttr,
-  removeAttr,
-  updateAttr,
-  restoreAttr,
+	extend,
+	//
+	element,
+	select,
+	siblings,
+	iterate,
+	//
+	on,
+	off,
+	once,
+	trigger,
+	//
+	addClass,
+	removeClass,
+	hasClass,
+	//
+	getAttr,
+	setAttr,
+	removeAttr,
+	updateAttr,
+	restoreAttr,
 } from './utils.js';
 
 // Accessibility based on https://plousia.com/blog/how-create-accessible-mobile-menu
@@ -28,11 +28,11 @@ import {
 // Formatters
 
 function formatYouTube(parts) {
-  return '//www.youtube.com/embed/' + parts[2];
+	return '//www.youtube.com/embed/' + parts[2];
 }
 
 function formatVimeo(parts) {
-  return '//player.vimeo.com/video/' + parts[3];
+	return '//player.vimeo.com/video/' + parts[3];
 }
 
 //
@@ -43,866 +43,904 @@ let LightboxInstance;
 
 class Lightbox {
 
-  static #_guid = 1;
+	static #_guid = 1;
 
-  static #_defaults = {
-    direction: document.dir,
-    customClass: '',
-    fileTypes: /\.(jpg|sjpg|jpeg|png|gif|webp)/i,
-    // iframeWidth: '900px',
-    // loop: false,
-    threshold: 50,
-    ordinal: true,
-    returnFocus: true,
-    templates: {
-      container: `
-<div class="fs-lightbox" role="dialog" aria-modal="true">
+	static #_defaults = {
+		direction: document.dir,
+		customClass: '',
+		label: 'Gallery',
+		fileTypes: /\.(jpg|sjpg|jpeg|png|gif|webp)/i,
+		// iframeWidth: '900px',
+		// loop: false,
+		threshold: 50,
+		ordinal: true,
+		returnFocus: true,
+		templates: {
+			container: `
+<dialog class="fs-lightbox">
   <div class="fs-lightbox-overlay"></div>
-  <div class="fs-lightbox-loading">[loading]</div>
-  <button type="button" class="fs-lightbox-close" aria-label="Close">[close]</button>
+  <div class="fs-lightbox-loading" role="status">[loading]</div>
+  <button type="button" class="fs-lightbox-close" autofocus>[close]</button>
   <div class="fs-lightbox-container"></div>
-  <button type="button" class="fs-lightbox-control fs-lightbox-control_previous" aria-label="Previous">[previous]</button>
-  <button type="button" class="fs-lightbox-control fs-lightbox-control_next" aria-label="Next">[next]</button>
-</div>`,
-      //       zoom: `
-      // <button type="button" class="fs-lightbox-zoom fs-lightbox-zoom_in" aria-label="Zoom In">[zoomIn]</button>
-      // <button type="button" class="fs-lightbox-zoom fs-lightbox-zoom_out" aria-label="Zoom Out">[zoomOut]</button>`,
-      close: `<span class="fs-lightbox-sr">Close</span><svg viewBox="-6 -6 24 24" fill="currentColor"><path d="M7.314 5.9l3.535-3.536A1 1 0 1 0 9.435.95L5.899 4.485 2.364.95A1 1 0 1 0 .95 2.364l3.535 3.535L.95 9.435a1 1 0 1 0 1.414 1.414l3.535-3.535 3.536 3.535a1 1 0 1 0 1.414-1.414L7.314 5.899z"></path></svg>`,
-      loading: '<span class="fs-lightbox-sr">Loading</span>',
-      previous: `<span class="fs-lightbox-sr">Previous</span><svg viewBox="-5 -5 24 24" fill="currentColor"><path d="M3.414 7.657l3.95 3.95A1 1 0 0 1 5.95 13.02L.293 7.364a.997.997 0 0 1 0-1.414L5.95.293a1 1 0 1 1 1.414 1.414l-3.95 3.95H13a1 1 0 0 1 0 2H3.414z"></path></svg>`,
-      next: `<span class="fs-lightbox-sr">Next</span><svg viewBox="-5 -5 24 24" fill="currentColor"><path d="M10.586 5.657l-3.95-3.95A1 1 0 0 1 8.05.293l5.657 5.657a.997.997 0 0 1 0 1.414L8.05 13.021a1 1 0 1 1-1.414-1.414l3.95-3.95H1a1 1 0 1 1 0-2h9.586z"></path></svg>`,
-      ordinal: `<span class="current">[current]</span> of <span class="total">[total]</span>`
-      // zoomIn: `<span class="fs-lightbox-sr">Zoom In</span><svg viewBox="-2.5 -2.5 24 24" fill="currentColor"><path d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zm6.32-1.094l3.58 3.58a1 1 0 1 1-1.415 1.413l-3.58-3.58a8 8 0 1 1 1.414-1.414zM9 7h2a1 1 0 0 1 0 2H9v2a1 1 0 0 1-2 0V9H5a1 1 0 1 1 0-2h2V5a1 1 0 1 1 2 0v2z"></path></svg>`,
-      // zoomOut: `<span class="fs-lightbox-sr">Zoom Out</span><svg viewBox="-2.5 -2.5 24 24" fill="currentColor"><path d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zm6.32-1.094l3.58 3.58a1 1 0 1 1-1.415 1.413l-3.58-3.58a8 8 0 1 1 1.414-1.414zM5 7h6a1 1 0 0 1 0 2H5a1 1 0 1 1 0-2z"></path></svg>`
-    },
-    videoProviders: {
-      youtube: {
-        pattern: /^(?:(?:https|http):\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be|youtube-nocookie\.com).*?(?:\/|v\/|u\/|embed\/|shorts\/|watch\?v=|(?<username>user\/))(?<id>[\w\-]{11})(?:\?|&|$)/,
-        format: formatYouTube
-      },
-      vimeo: {
-        pattern: /(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^\/]*)\/videos\/|album\/(\d+)\/video\/|video\/|)(\d+)(?:$|\/|\?)/,
-        format: formatVimeo
-      }
-    }
-  };
-
-  static defaults(options) {
-    this.#_defaults = extend(true, this.#_defaults, options);
-  }
-
-  static construct(selector, options) {
-    let targets = select(selector);
-
-    iterate(targets, (el) => {
-      if (!el.Lightbox) {
-        new Lightbox(el, options);
-      }
-    });
-
-    return targets;
-  }
-
-  //
-
-  constructor(el, options) {
-    if (el.Lightbox) {
-      console.warn('Lightbox: Instance already exists', el);
-      return;
-    }
+  <button type="button" class="fs-lightbox-control fs-lightbox-control_previous">[previous]</button>
+  <button type="button" class="fs-lightbox-control fs-lightbox-control_next">[next]</button>
+  <div class="fs-lightbox-status fs-lightbox-sr" aria-live="polite" aria-atomic="true"></div>
+</dialog>`,
+			//       zoom: `
+			// <button type="button" class="fs-lightbox-zoom fs-lightbox-zoom_in" aria-label="Zoom In">[zoomIn]</button>
+			// <button type="button" class="fs-lightbox-zoom fs-lightbox-zoom_out" aria-label="Zoom Out">[zoomOut]</button>`,
+			close: `<span class="fs-lightbox-sr">Close</span><svg viewBox="-6 -6 24 24" fill="currentColor"><path d="M7.314 5.9l3.535-3.536A1 1 0 1 0 9.435.95L5.899 4.485 2.364.95A1 1 0 1 0 .95 2.364l3.535 3.535L.95 9.435a1 1 0 1 0 1.414 1.414l3.535-3.535 3.536 3.535a1 1 0 1 0 1.414-1.414L7.314 5.899z"></path></svg>`,
+			loading: '<span class="fs-lightbox-sr">Loading</span>',
+			previous: `<span class="fs-lightbox-sr">Previous</span><svg viewBox="-5 -5 24 24" fill="currentColor"><path d="M3.414 7.657l3.95 3.95A1 1 0 0 1 5.95 13.02L.293 7.364a.997.997 0 0 1 0-1.414L5.95.293a1 1 0 1 1 1.414 1.414l-3.95 3.95H13a1 1 0 0 1 0 2H3.414z"></path></svg>`,
+			next: `<span class="fs-lightbox-sr">Next</span><svg viewBox="-5 -5 24 24" fill="currentColor"><path d="M10.586 5.657l-3.95-3.95A1 1 0 0 1 8.05.293l5.657 5.657a.997.997 0 0 1 0 1.414L8.05 13.021a1 1 0 1 1-1.414-1.414l3.95-3.95H1a1 1 0 1 1 0-2h9.586z"></path></svg>`,
+			ordinal: `<span class="current">[current]</span> of <span class="total">[total]</span>`
+			// zoomIn: `<span class="fs-lightbox-sr">Zoom In</span><svg viewBox="-2.5 -2.5 24 24" fill="currentColor"><path d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zm6.32-1.094l3.58 3.58a1 1 0 1 1-1.415 1.413l-3.58-3.58a8 8 0 1 1 1.414-1.414zM9 7h2a1 1 0 0 1 0 2H9v2a1 1 0 0 1-2 0V9H5a1 1 0 1 1 0-2h2V5a1 1 0 1 1 2 0v2z"></path></svg>`,
+			// zoomOut: `<span class="fs-lightbox-sr">Zoom Out</span><svg viewBox="-2.5 -2.5 24 24" fill="currentColor"><path d="M8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zm6.32-1.094l3.58 3.58a1 1 0 1 1-1.415 1.413l-3.58-3.58a8 8 0 1 1 1.414-1.414zM5 7h6a1 1 0 0 1 0 2H5a1 1 0 1 1 0-2z"></path></svg>`
+		},
+		videoProviders: {
+			youtube: {
+				pattern: /^(?:(?:https|http):\/\/)?(?:www\.)?(?:youtube\.com|youtu\.be|youtube-nocookie\.com).*?(?:\/|v\/|u\/|embed\/|shorts\/|watch\?v=|(?<username>user\/))(?<id>[\w\-]{11})(?:\?|&|$)/,
+				format: formatYouTube
+			},
+			vimeo: {
+				pattern: /(?:www\.|player\.)?vimeo.com\/(?:channels\/(?:\w+\/)?|groups\/([^\/]*)\/videos\/|album\/(\d+)\/video\/|video\/|)(\d+)(?:$|\/|\?)/,
+				format: formatVimeo
+			}
+		}
+	};
+
+	static defaults(options) {
+		this.#_defaults = extend(true, this.#_defaults, options);
+	}
+
+	static construct(selector, options) {
+		let targets = select(selector);
+
+		iterate(targets, (el) => {
+			if (!el.Lightbox) {
+				new Lightbox(el, options);
+			}
+		});
+
+		return targets;
+	}
+
+	//
+
+	constructor(el, options) {
+		if (el.Lightbox) {
+			console.warn('Lightbox: Instance already exists', el);
+			return;
+		}
+
+		// Parse JSON Options
+
+		let optionsData = {};
+		let dataset = el.dataset;
+
+		try {
+			optionsData = JSON.parse(dataset.lightboxOptions || '{}');
+		} catch (e) {
+			console.warn('Lightbox: Error parsing options JSON', el);
+		}
+
+		// Internal Data
 
-    // Parse JSON Options
+		Object.assign(this, extend(true, this.constructor.#_defaults, options || {}, optionsData));
 
-    let optionsData = {};
-    let dataset = el.dataset;
-
-    try {
-      optionsData = JSON.parse(dataset.lightboxOptions || '{}');
-    } catch (e) {
-      console.warn('Lightbox: Error parsing options JSON', el);
-    }
-
-    // Internal Data
-
-    Object.assign(this, extend(true, this.constructor.#_defaults, options || {}, optionsData));
+		this.el = el;
+		this.guid = this.constructor.#_guid++;
+		this.guidClass = `fs-lightbox-element-${this.guid}`;
+		this.gallery = dataset.lightboxGallery || null;
+		this.isOpen = false;
+		this.isTouching = false;
+		this.isRTL = this.direction == 'rtl';
+
+		// Enhance trigger
+
+		addClass(this.el, this.guidClass);
+
+		setAttr(this.el, {
+			role: 'button',
+			'aria-haspopup': 'dialog'
+		});
 
-    this.el = el;
-    this.guid = this.constructor.#_guid++;
-    this.guidClass = `fs-lightbox-element-${this.guid}`;
-    this.gallery = dataset.lightboxGallery || null;
-    this.isOpen = false;
-    this.isTouching = false;
-    this.isRTL = this.direction == 'rtl';
+		if (!getAttr(this.el, 'aria-label') && !getAttr(this.el, 'aria-labelledby')) {
+			let img = select('img', this.el)[0];
+			let label = dataset.lightboxCaption || (img ? getAttr(img, 'alt') : null) || 'Open Lightbox';
 
-    //
+			setAttr(this.el, 'aria-label', label);
+		}
 
-    addClass(this.el, this.guidClass);
+		on(this.el, 'click', this.#onClick);
 
-    on(this.el, 'click', this.#onClick);
-
-    el.Lightbox = this;
-  }
-
-  //
-
-  destroy() {
-    this.close();
-
-    removeClass(this.el, this.guidClass);
+		on(this.el, 'keydown', (e) => {
+			if (e.key === ' ') {
+				e.preventDefault();
+				this.open();
+			}
+		});
+
+		el.Lightbox = this;
+	}
 
-    off(this.el, 'click', this.#onClick);
+	//
 
-    this.el.Lightbox = null;
+	destroy() {
+		this.close();
 
-    delete this.el.Lightbox;
-  }
+		removeClass(this.el, this.guidClass);
 
-  //
+		off(this.el, 'click', this.#onClick);
 
-  open(index) {
-    if (this.isOpen) {
-      return;
-    }
+		this.el.Lightbox = null;
 
-    let promise;
+		delete this.el.Lightbox;
+	}
 
-    if (LightboxInstance) {
-      promise = LightboxInstance.close();
-    } else {
-      promise = new Promise((resolve, reject) => {
-        resolve(this.el);
-      });
-    }
+	//
 
-    promise.then(() => {
-      this.index = index;
+	open(index) {
+		if (this.isOpen) {
+			return;
+		}
 
-      this.#buildItems();
+		let promise = LightboxInstance ? LightboxInstance.close() : Promise.resolve();
 
-      this.maxIndex = this.items.length - 1;
+		promise.then(() => {
+			this.index = index;
 
-      this.listeners = {
-        'close': this.#onClose(),
-        'next': this.#onNext(),
-        'previous': this.#onPrevious(),
-        'container': this.#onContainerClick(),
-        'keydown': this.#onKeyDown(),
-        'pointerdown': this.#onPointerDown(),
-        'pointermove': this.#onPointerMove(),
-        'pointerup': this.#onPointerUp(),
-        // 'zoomin': this.#onZoomIn(),
-        // 'zoomout': this.#onZoomOut(),
-      };
+			this.#buildItems();
 
-      this.#draw();
+			this.maxIndex = this.items.length - 1;
 
-      this.#setPositions();
+			this.listeners = {
+				'close': this.#onClose(),
+				'next': this.#onNext(),
+				'previous': this.#onPrevious(),
+				'container': this.#onContainerClick(),
+				'keydown': this.#onKeyDown(),
+				'pointerdown': this.#onPointerDown(),
+				'pointermove': this.#onPointerMove(),
+				'pointerup': this.#onPointerUp(),
+				// 'zoomin': this.#onZoomIn(),
+				// 'zoomout': this.#onZoomOut(),
+			};
 
-      this.#hideSiblings();
+			this.#draw();
 
-      setTimeout(() => {
-        addClass(this.lightboxEl, 'fs-lightbox-open');
+			if (typeof this.lightboxEl.showModal === 'function') {
+				this.lightboxEl.showModal();
+			}
 
-        this.isOpen = true;
+			this.#setPositions();
 
-        // this.lightboxEl.focus();
-        this.closeEl.focus();
+			// this.#hideSiblings();
 
-        LightboxInstance = this;
+			setTimeout(() => {
+				addClass(this.lightboxEl, 'fs-lightbox-open');
 
-        trigger(window, 'lightbox:open', {
-          el: this.el
-        });
-      }, 10);
-    });
-  }
+				this.isOpen = true;
 
-  close() {
-    if (!this.isOpen) {
-      return;
-    }
+				// this.lightboxEl.focus();
+				// this.closeEl.focus();
 
-    removeClass(this.lightboxEl, 'fs-lightbox-open');
+				LightboxInstance = this;
 
-    this.#showSiblings();
+				trigger(window, 'lightbox:open', {
+					el: this.el
+				});
+			}, 10);
+		});
+	}
 
-    off(window, 'keydown', this.listeners.keydown);
-    off(window, 'lightbox:previous', this.listeners.previous);
-    off(window, 'lightbox:next', this.listeners.next);
-    off(window, 'lightbox:close', this.listeners.close);
+	close() {
+		if (!this.isOpen) {
+			return;
+		}
 
-    // off(select('.fs-lightbox-previous', this.el), 'click', this.listeners.previous);
-    // off(select('.fs-lightbox-next', this.el), 'click', this.listeners.next);
+		removeClass(this.lightboxEl, 'fs-lightbox-open');
 
-    let promise = new Promise((resolve, reject) => {
-      let cb = (e) => {
-        if (!hasClass(e.target, 'fs-lightbox')) {
-          return;
-        }
+		// this.#showSiblings();
 
-        iterate(this.items, (item, index) => {
-          if (item.isElement) {
-            item.targetEl.append(...item.frameEl.childNodes);
-          }
-        });
+		off(window, 'keydown', this.listeners.keydown);
+		off(window, 'lightbox:previous', this.listeners.previous);
+		off(window, 'lightbox:next', this.listeners.next);
+		off(window, 'lightbox:close', this.listeners.close);
 
-        off(this.lightboxEl, 'transitionend', cb);
+		// off(select('.fs-lightbox-previous', this.el), 'click', this.listeners.previous);
+		// off(select('.fs-lightbox-next', this.el), 'click', this.listeners.next);
 
-        this.lightboxEl.remove();
+		let promise = new Promise((resolve, reject) => {
+			let cb = (e) => {
+				if (!hasClass(e.target, 'fs-lightbox')) {
+					return;
+				}
 
-        this.isOpen = false;
+				iterate(this.items, (item, index) => {
+					if (item.isElement) {
+						item.targetEl.append(...item.frameEl.childNodes);
+					}
+				});
 
-        if (this.returnFocus) {
-          this.el.focus();
-        }
+				off(this.lightboxEl, 'transitionend', cb);
 
-        trigger(window, 'lightbox:close', {
-          el: this.el
-        });
+				if (typeof this.lightboxEl.close === 'function') {
+					this.lightboxEl.close();
+				}
 
-        LightboxInstance = null;
+				this.lightboxEl.remove();
 
-        resolve(this.el);
-      };
+				this.isOpen = false;
 
-      on(this.lightboxEl, 'transitionend', cb);
-    });
+				// if (this.returnFocus) {
+				// 	this.el.focus();
+				// }
 
-    return promise;
-  }
-
-  //
-
-  next() {
-    this.index++;
-    this.#checkIndex();
-
-    this.#setPositions();
-  }
-
-  previous() {
-    this.index--;
-    this.#checkIndex();
-
-    this.#setPositions();
-  }
-
-  jump(index) {
-    this.index = index;
-    this.#checkIndex();
-
-    this.#setPositions();
-  }
-
-  //
-
-  #buildItems() {
-    this.selector = this.gallery ? `[data-lightbox-gallery="${this.gallery}"]` : `.${this.guidClass}`;
-
-    let targets = select(this.selector);
-
-    this.items = [];
-
-    iterate(targets, (el, i) => {
-      if (el.tagName === 'A') {
-        let url = window.location.href.replace(window.location.hash, '');
-        let hash = el.hash;
-        let source = el.href.replace(hash, '');
-        let type = el.dataset.lightboxType || '';
-        let isImage = (type === 'image') || this.#checkImage(source);
-        let isVideo = (type === 'video') || !!this.#checkVideo(source);
-        let isElement = (type === 'element') || (!isImage && !isVideo && (source.indexOf(url) > -1 && hash.substr(0, 1) === '#'));
-        let isIframe = (type === 'url') || (!isImage && !isVideo && !isElement && source.substr(0, 4) === 'http');
-
-        if (!this.index && el == this.el) {
-          this.index = i;
-        }
-
-        this.items.push({
-          index: i,
-          source: el.href,
-          hash: hash,
-          // type: type,
-          isLoaded: false,
-          isImage: isImage,
-          isVideo: isVideo,
-          isIframe: isIframe,
-          isElement: isElement,
-          caption: el.dataset.lightboxCaption || getAttr(el, 'title'),
-          // zoomed: false,
-        });
-      }
-    });
-  }
-
-  //
-
-  #draw() {
-    let html = this.templates.container
-      .replace('[close]', this.templates.close)
-      .replace('[loading]', this.templates.loading)
-      .replace('[previous]', this.templates.previous)
-      .replace('[next]', this.templates.next);
-
-    document.body.insertAdjacentHTML('beforeend', html);
-
-    this.lightboxEl = select('.fs-lightbox')[0];
-    this.overlayEl = select('.fs-lightbox-overlay', this.lightboxEl)[0];
-    this.closeEl = select('.fs-lightbox-close', this.lightboxEl)[0];
-    this.loadingEl = select('.fs-lightbox-loading', this.lightboxEl)[0];
-    this.containerEl = select('.fs-lightbox-container', this.lightboxEl)[0];
-    this.controlPreviousEl = select('.fs-lightbox-control_previous', this.lightboxEl)[0];
-    this.controlNextEl = select('.fs-lightbox-control_next', this.lightboxEl)[0];
-
-    addClass(this.lightboxEl, this.customClass);
-
-    if (this.isRTL) {
-      addClass(this.lightboxEl, `fs-lightbox-rtl`);
-    }
-
-    if (this.items.length > 1) {
-      addClass(this.lightboxEl, 'fs-lightbox-gallery');
-    }
-
-    iterate(this.items, (item, index) => {
-      if (item.isImage) {
-        this.#drawImage(item, index);
-      }
-      if (item.isVideo) {
-        this.#drawVideo(item, index);
-      }
-      if (item.isIframe) {
-        this.#drawIframe(item, index);
-      }
-      if (item.isElement) {
-        this.#drawElement(item, index);
-      }
-
-      if (this.items.length > 1) {
-        on(item.mediaEl, 'pointerdown', this.listeners.pointerdown);
-      }
-    });
-
-    once(this.closeEl, 'click', this.listeners.close);
-    on(this.controlPreviousEl, 'click', this.listeners.previous);
-    on(this.controlNextEl, 'click', this.listeners.next);
-    on(this.containerEl, 'click', this.listeners.container);
-    on(window, 'keydown', this.listeners.keydown);
-    on(window, 'lightbox:previous', this.listeners.previous);
-    on(window, 'lightbox:next', this.listeners.next);
-    on(window, 'lightbox:close', this.listeners.close);
-  }
-
-  //
-
-  #drawImage(item, index) {
-    let itemEl = element('div');
-    let wrapEl = element('div');
-    let mediaEl = element('div');
-    let imgEl = element('img');
-
-    addClass(itemEl, 'fs-lightbox-item', `fs-lightbox-item_${index}`);
-    addClass(wrapEl, 'fs-lightbox-wrap');
-    addClass(mediaEl, 'fs-lightbox-media', 'fs-lightbox-media_image');
-    addClass(imgEl, 'fs-lightbox-image');
-
-    setAttr(imgEl, {
-      'data-src': item.source,
-      'draggable': 'false',
-      'alt': item.caption || '',
-    });
-
-    mediaEl.append(imgEl);
-    wrapEl.append(mediaEl);
-    itemEl.append(wrapEl);
-
-    this.#checkDetails(item, itemEl);
-
-    this.containerEl.append(itemEl);
-
-    item.el = itemEl;
-    item.mediaEl = mediaEl;
-
-    // // zoom
-
-    // let zoom = this.templates.zoom
-    //   .replace('[zoomIn]', this.templates.zoomIn)
-    //   .replace('[zoomOut]', this.templates.zoomOut);
-
-    // itemEl.insertAdjacentHTML('beforeend', zoom);
-
-    // let zoomInEl = select('.fs-lightbox-zoom_in', itemEl)[0];
-    // let zoomOutEl = select('.fs-lightbox-zoom_out', itemEl)[0];
-
-    // console.log(zoomInEl);
-
-    // on(zoomInEl, 'click', this.listeners.zoomin);
-    // on(zoomOutEl, 'click', this.listeners.zoomout);
-  }
-
-  #drawVideo(item, index) {
-    let url = this.#checkVideo(item.source);
-    let qs = item.source.split('?');
-    let parts = [
-      '&origin=' + encodeURIComponent(window.location.protocol + '//' + window.location.hostname),
-      '&enablejsapi=1'
-    ];
-
-    if (qs.length >= 2) {
-      parts.push(qs.slice(1)[0].trim());
-    }
-
-    let source = `${url}?${parts.join('&')}`;
-
-    let itemEl = element('div');
-    let wrapEl = element('div');
-    let mediaEl = element('div');
-    let frameEl = element('div');
-    let iframeEl = element('iframe');
-
-    addClass(itemEl, 'fs-lightbox-item', `fs-lightbox-item_${index}`);
-    addClass(wrapEl, 'fs-lightbox-wrap');
-    addClass(mediaEl, 'fs-lightbox-media', 'fs-lightbox-media_video');
-    addClass(frameEl, 'fs-lightbox-video');
-
-    setAttr(iframeEl, {
-      'frameborder': '0',
-      'seamless': 'seamless',
-      'allowfullscreen': '',
-      'allow': 'autoplay; encrypted-media',
-      'referrerpolicy': 'strict-origin-when-cross-origin',
-      'data-src': source,
-      'title': item.caption || 'Lightbox Video',
-    });
-
-    frameEl.append(iframeEl);
-    mediaEl.append(frameEl);
-    wrapEl.append(mediaEl);
-    itemEl.append(wrapEl);
-
-    this.#checkDetails(item, itemEl);
-
-    this.containerEl.append(itemEl);
-
-    item.el = itemEl;
-    item.mediaEl = mediaEl;
-  }
-
-  #drawIframe(item, index) {
-    let itemEl = element('div');
-    let wrapEl = element('div');
-    let mediaEl = element('div');
-    let frameEl = element('div');
-    let iframeEl = element('iframe');
-
-    addClass(itemEl, 'fs-lightbox-item', `fs-lightbox-item_${index}`);
-    addClass(wrapEl, 'fs-lightbox-wrap');
-    addClass(mediaEl, 'fs-lightbox-media', 'fs-lightbox-media_iframe');
-    addClass(frameEl, 'fs-lightbox-iframe');
-
-    setAttr(iframeEl, {
-      'frameborder': '0',
-      'seamless': 'seamless',
-      'data-src': item.source,
-      'title': item.caption || 'Lightbox iFrame',
-    });
-
-    frameEl.append(iframeEl);
-    mediaEl.append(frameEl);
-    wrapEl.append(mediaEl);
-    itemEl.append(wrapEl);
-
-    this.#checkDetails(item, itemEl);
-
-    this.containerEl.append(itemEl);
-
-    item.el = itemEl;
-    item.mediaEl = mediaEl;
-    item.frameEl = frameEl;
-  }
-
-  #drawElement(item, index) {
-    let itemEl = element('div');
-    let wrapEl = element('div');
-    let mediaEl = element('div');
-    let frameEl = element('div');
-
-    item.targetEl = select(item.hash)[0];
-
-    addClass(itemEl, 'fs-lightbox-item', `fs-lightbox-item_${index}`, 'fs-lightbox-loaded');
-    addClass(wrapEl, 'fs-lightbox-wrap');
-    addClass(mediaEl, 'fs-lightbox-media', 'fs-lightbox-media_element');
-    addClass(frameEl, 'fs-lightbox-element');
-
-    frameEl.append(...item.targetEl.childNodes);
-    mediaEl.append(frameEl);
-    wrapEl.append(mediaEl);
-    itemEl.append(wrapEl);
-
-    this.#checkDetails(item, itemEl);
-
-    this.containerEl.append(itemEl);
-
-    item.isLoaded = true;
-
-    item.el = itemEl;
-    item.mediaEl = mediaEl;
-    item.frameEl = frameEl;
-
-    // on(select('.fs-lightbox-previous', item.el), 'click', () => {
-    //   console.log(this);
-    // });
-    // on(select('.fs-lightbox-next', item.el), 'click', this.listeners.next);
-  }
-
-  //
-
-  #setPositions() {
-    iterate(this.items, (item, index) => {
-      removeClass(item.el, 'fs-lightbox-active', 'fs-lightbox-item_previous', 'fs-lightbox-item_next');
-
-      if (index === this.index) {
-        addClass(item.el, 'fs-lightbox-active');
-
-        removeAttr(item.el, 'aria-hidden');
-
-        if (!item.isLoaded) {
-          this.#showLoading();
-
-          this.#loadItem(item, index);
-        } else {
-          this.#hideLoading();
-        }
-      } else {
-        once(item.el, 'transitionend', (e) => {
-          this.#unloadItem(item, index);
-        });
-
-        setAttr(item.el, 'aria-hidden', 'true');
-      }
-
-      if (this.loop && this.index == this.maxIndex && index == 0) {
-        addClass(item.el, 'fs-lightbox-item_next');
-      } else if (this.loop && this.index == 0 && index == this.maxIndex) {
-        addClass(item.el, 'fs-lightbox-item_previous');
-      } else if (index < this.index) {
-        addClass(item.el, 'fs-lightbox-item_previous');
-      } else if (index > this.index) {
-        addClass(item.el, 'fs-lightbox-item_next');
-      }
-    });
-
-    if (!this.loop) {
-      setAttr(this.controlPreviousEl, 'disabled', (this.index === 0));
-      setAttr(this.controlNextEl, 'disabled', (this.index === this.maxIndex));
-    }
-  }
-
-  //
-
-  #loadItem(item, index) {
-    if (index !== this.index) {
-      return;
-    }
-
-    let media = select('[data-src]', item.el);
-
-    iterate(media, (m) => {
-      once(m, 'load', (e) => {
-        addClass(item.el, 'fs-lightbox-loaded');
-
-        item.isLoaded = true;
-
-        this.#hideLoading();
-      });
-
-      m.src = getAttr(m, 'data-src');
-    });
-  }
-
-  #unloadItem(item, index) {
-    if (index == this.index) {
-      return;
-    }
-
-    // if (item.isImage) {
-    //   this.#resetZoom(item);
-    // }
-
-    if ((item.isVideo || item.isIframe) && item.isLoaded) {
-      let media = select('[data-src]', item.el);
-
-      iterate(media, (m) => {
-        m.src = '';
-      });
-
-      removeClass(item.el, 'fs-lightbox-loaded');
-
-      item.isLoaded = false;
-    }
-  }
-
-  //
-
-  #hideLoading() {
-    removeClass(this.loadingEl, 'fs-lightbox-visible');
-  }
-
-  #showLoading() {
-    addClass(this.loadingEl, 'fs-lightbox-visible');
-  }
-
-  //
-
-  #hideSiblings() {
-    updateAttr(siblings(this.lightboxEl), 'aria-hidden', 'true', 'lightbox');
-  }
-
-  #showSiblings() {
-    restoreAttr(siblings(this.lightboxEl), 'aria-hidden', 'lightbox');
-  }
-
-  //
-
-  #checkIndex() {
-    if (this.index < 0) {
-      this.index = this.loop ? this.maxIndex : 0;
-    }
-    if (this.index >= this.items.length) {
-      this.index = this.loop ? 0 : this.maxIndex;
-    }
-  }
-
-  #checkImage(source) {
-    return (source.match(this.fileTypes) !== null || source.substr(0, 10) === 'data:image');
-  }
-
-  #checkVideo(source) {
-    for (let i in this.videoProviders) {
-      let provider = this.videoProviders[i];
-      let parts = source.match(provider.pattern);
-
-      if (parts !== null) {
-        return provider.format.call(this, parts);
-      }
-    }
-
-    return false;
-  }
-
-  #checkDetails(item, el) {
-    let details = '';
-
-    if (this.items.length > 1 && this.ordinal) {
-      let ordinal = this.templates.ordinal
-        .replace('[current]', item.index + 1)
-        .replace('[total]', this.items.length);
-
-      details += `<div class="fs-lightbox-ordinal">${ordinal}</div>`;
-    }
-
-    if (item.caption) {
-      details += `<div class="fs-lightbox-caption">${item.caption}</div>`;
-    }
-
-    if (details !== '') {
-      el.insertAdjacentHTML('beforeend', `<div class="fs-lightbox-details">${details}</div>`);
-    }
-  }
-
-  //
-
-  #onClick(e) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    this.Lightbox.open();
-  }
-
-  #onContainerClick() {
-    return (e) => {
-      let item = this.items[this.index].mediaEl;
-
-      if (e.target !== item && !item.contains(e.target)) {
-        this.close();
-      } else {
-        this.#checkClick(e);
-      }
-    };
-  }
-
-  #checkClick(e) {
-    if (hasClass(e.target, 'fs-lightbox-trigger-previous')) {
-      this.previous();
-    }
-    if (hasClass(e.target, 'fs-lightbox-trigger-next')) {
-      this.next();
-    }
-    if (hasClass(e.target, 'fs-lightbox-trigger-close')) {
-      this.close();
-    }
-  }
-
-  #onClose() {
-    return (e) => {
-      this.close();
-    };
-  }
-
-  #onPrevious() {
-    return (e) => {
-      this.previous();
-    };
-  }
-
-  #onNext() {
-    return (e) => {
-      this.next();
-    };
-  }
-
-  #onKeyDown() {
-    return (e) => {
-      if (e.key === 'ArrowLeft') {
-        if (this.isRTL) {
-          this.next();
-        } else {
-          this.previous();
-        }
-      }
-      if (e.key === 'ArrowRight') {
-        if (this.isRTL) {
-          this.previous();
-        } else {
-          this.next();
-        }
-      }
-      if (e.key === 'Escape') {
-        this.close();
-      }
-    };
-  }
-
-  //
-
-  #onPointerDown() {
-    return (e) => {
-      if (
-        !hasClass(e.target, 'fs-lightbox-trigger-previous') &&
-        !hasClass(e.target, 'fs-lightbox-trigger-next') &&
-        !hasClass(e.target, 'fs-lightbox-trigger-close') &&
-        e.target.tagName !== 'A' // don't act on links
-      ) {
-        this.isTouching = true;
-        this.pointerStartX = e.clientX;
-        this.pointerStartY = e.clientY;
-
-        this.containerEl.setPointerCapture(e.pointerId);
-
-        addClass(this.containerEl, 'fs-lightbox-touching');
-
-        on(this.containerEl, 'pointermove', this.listeners.pointermove);
-        on(this.containerEl, 'pointerup', this.listeners.pointerup);
-      }
-    }
-  }
-
-  #onPointerMove() {
-    return (e) => {
-      let item = this.items[this.index];
-
-      // if (item.zoomed) {
-      //   // handle pan
-      //   let diffX = -(this.pointerStartX - e.clientX);
-      //   let diffY = -(this.pointerStartY - e.clientY);
-
-
-      // } else {
-      let diff = -(this.pointerStartX - e.clientX);
-
-      item.el.style.transform = `translate3d(${diff}px, 0, 0)`;
-      // }
-    }
-  }
-
-  #onPointerUp() {
-    return (e) => {
-      let item = this.items[this.index];
-
-      removeClass(this.containerEl, 'fs-lightbox-touching');
-
-      off(this.containerEl, 'pointermove', this.listeners.pointermove);
-      off(this.containerEl, 'pointerup', this.listeners.pointerup);
-
-      // if (item.zoomed) {
-      //   // handle pan
-      // } else {
-      let diff = this.pointerStartX - e.clientX;
-
-      item.el.style.transform = null;
-
-      if (Math.abs(diff) > this.threshold) {
-        if (diff < 0) {
-          if (this.isRTL) {
-            this.next();
-          } else {
-            this.previous();
-          }
-        }
-        if (diff > 0) {
-          if (this.isRTL) {
-            this.previous();
-          } else {
-            this.next();
-          }
-        }
-      }
-      // }
-
-      this.isTouching = false;
-
-      once(this.containerEl, 'click', (e) => {
-        e.stopPropagation(); // prevent closing when swiping
-      }, true);
-    }
-  }
-
-  // //
-
-  // #onZoomIn() {
-  //   return (e) => {
-  //     e.stopPropagation();
-
-  //     console.log('Zoom in');
-
-  //     let item = this.items[this.index];
-
-  //     item.zoomed = true;
-
-  //     addClass(item.el, 'fs-lightbox-zoomed');
-
-  //     console.log(item, item.el);
-  //   }
-  // }
-
-  // #onZoomOut() {
-  //   return (e) => {
-  //     e.stopPropagation();
-
-  //     console.log('Zoom out');
-
-  //     let item = this.items[this.index];
-
-  //     this.#resetZoom(item);
-  //   }
-  // }
-
-  // #resetZoom(item) {
-  //   item.zoomed = false;
-
-  //   removeClass(item.el, 'fs-lightbox-zoomed');
-
-  //   // item.el.style.transform
+				trigger(window, 'lightbox:close', {
+					el: this.el
+				});
+
+				LightboxInstance = null;
+
+				resolve(this.el);
+			};
+
+			on(this.lightboxEl, 'transitionend', cb);
+		});
+
+		return promise;
+	}
+
+	//
+
+	next() {
+		this.index++;
+		this.#checkIndex();
+
+		this.#setPositions();
+	}
+
+	previous() {
+		this.index--;
+		this.#checkIndex();
+
+		this.#setPositions();
+	}
+
+	jump(index) {
+		this.index = index;
+		this.#checkIndex();
+
+		this.#setPositions();
+	}
+
+	//
+
+	#buildItems() {
+		this.selector = this.gallery ? `[data-lightbox-gallery="${this.gallery}"]` : `.${this.guidClass}`;
+
+		let targets = select(this.selector);
+
+		this.items = [];
+
+		iterate(targets, (el, i) => {
+			if (el.tagName === 'A') {
+				let url = window.location.href.replace(window.location.hash, '');
+				let hash = el.hash;
+				let source = el.href.replace(hash, '');
+				let type = el.dataset.lightboxType || '';
+				let isImage = (type === 'image') || this.#checkImage(source);
+				let isVideo = (type === 'video') || !!this.#checkVideo(source);
+				let isElement = (type === 'element') || (!isImage && !isVideo && (source.indexOf(url) > -1 && hash.substr(0, 1) === '#'));
+				let isIframe = (type === 'url') || (!isImage && !isVideo && !isElement && source.substr(0, 4) === 'http');
+
+				if (!this.index && el == this.el) {
+					this.index = i;
+				}
+
+				this.items.push({
+					index: i,
+					source: el.href,
+					hash: hash,
+					// type: type,
+					isLoaded: false,
+					isImage: isImage,
+					isVideo: isVideo,
+					isIframe: isIframe,
+					isElement: isElement,
+					caption: el.dataset.lightboxCaption || getAttr(el, 'title'),
+					// zoomed: false,
+				});
+			}
+		});
+	}
+
+	//
+
+	#draw() {
+		let html = this.templates.container
+			.replace('[close]', this.templates.close)
+			.replace('[loading]', this.templates.loading)
+			.replace('[previous]', this.templates.previous)
+			.replace('[next]', this.templates.next);
+
+		document.body.insertAdjacentHTML('beforeend', html);
+
+		this.lightboxEl = select('.fs-lightbox')[0];
+		this.overlayEl = select('.fs-lightbox-overlay', this.lightboxEl)[0];
+		this.closeEl = select('.fs-lightbox-close', this.lightboxEl)[0];
+		this.loadingEl = select('.fs-lightbox-loading', this.lightboxEl)[0];
+		this.containerEl = select('.fs-lightbox-container', this.lightboxEl)[0];
+		this.statusEl = select('.fs-lightbox-status', this.lightboxEl)[0];
+		this.controlPreviousEl = select('.fs-lightbox-control_previous', this.lightboxEl)[0];
+		this.controlNextEl = select('.fs-lightbox-control_next', this.lightboxEl)[0];
+
+		addClass(this.lightboxEl, this.customClass);
+		setAttr(this.lightboxEl, 'aria-label', this.label);
+
+		if (this.isRTL) {
+			addClass(this.lightboxEl, `fs-lightbox-rtl`);
+		}
+
+		if (this.items.length > 1) {
+			addClass(this.lightboxEl, 'fs-lightbox-gallery');
+		}
+
+		iterate(this.items, (item, index) => {
+			if (item.isImage) {
+				this.#drawImage(item, index);
+			}
+			if (item.isVideo) {
+				this.#drawVideo(item, index);
+			}
+			if (item.isIframe) {
+				this.#drawIframe(item, index);
+			}
+			if (item.isElement) {
+				this.#drawElement(item, index);
+			}
+
+			if (this.items.length > 1) {
+				on(item.mediaEl, 'pointerdown', this.listeners.pointerdown);
+			}
+		});
+
+		once(this.closeEl, 'click', this.listeners.close);
+		on(this.controlPreviousEl, 'click', this.listeners.previous);
+		on(this.controlNextEl, 'click', this.listeners.next);
+		on(this.containerEl, 'click', this.listeners.container);
+		on(this.lightboxEl, 'cancel', (e) => {
+			this.close();
+		});
+		on(window, 'keydown', this.listeners.keydown);
+		on(window, 'lightbox:previous', this.listeners.previous);
+		on(window, 'lightbox:next', this.listeners.next);
+		on(window, 'lightbox:close', this.listeners.close);
+	}
+
+	//
+
+	#drawImage(item, index) {
+		let itemEl = element('div');
+		let wrapEl = element('div');
+		let mediaEl = element('div');
+		let imgEl = element('img');
+
+		addClass(itemEl, 'fs-lightbox-item', `fs-lightbox-item_${index}`);
+		addClass(wrapEl, 'fs-lightbox-wrap');
+		addClass(mediaEl, 'fs-lightbox-media', 'fs-lightbox-media_image');
+		addClass(imgEl, 'fs-lightbox-image');
+
+		setAttr(imgEl, {
+			'data-src': item.source,
+			'draggable': 'false',
+			'alt': item.caption || '',
+		});
+
+		mediaEl.append(imgEl);
+		wrapEl.append(mediaEl);
+		itemEl.append(wrapEl);
+
+		this.#checkDetails(item, itemEl);
+
+		this.containerEl.append(itemEl);
+
+		item.el = itemEl;
+		item.mediaEl = mediaEl;
+
+		// // zoom
+
+		// let zoom = this.templates.zoom
+		//   .replace('[zoomIn]', this.templates.zoomIn)
+		//   .replace('[zoomOut]', this.templates.zoomOut);
+
+		// itemEl.insertAdjacentHTML('beforeend', zoom);
+
+		// let zoomInEl = select('.fs-lightbox-zoom_in', itemEl)[0];
+		// let zoomOutEl = select('.fs-lightbox-zoom_out', itemEl)[0];
+
+		// console.log(zoomInEl);
+
+		// on(zoomInEl, 'click', this.listeners.zoomin);
+		// on(zoomOutEl, 'click', this.listeners.zoomout);
+	}
+
+	#drawVideo(item, index) {
+		let url = this.#checkVideo(item.source);
+		let qs = item.source.split('?');
+		let parts = [
+			'&origin=' + encodeURIComponent(window.location.protocol + '//' + window.location.hostname),
+			'&enablejsapi=1'
+		];
+
+		if (qs.length >= 2) {
+			parts.push(qs.slice(1)[0].trim());
+		}
+
+		let source = `${url}?${parts.join('&')}`;
+
+		let itemEl = element('div');
+		let wrapEl = element('div');
+		let mediaEl = element('div');
+		let frameEl = element('div');
+		let iframeEl = element('iframe');
+
+		addClass(itemEl, 'fs-lightbox-item', `fs-lightbox-item_${index}`);
+		addClass(wrapEl, 'fs-lightbox-wrap');
+		addClass(mediaEl, 'fs-lightbox-media', 'fs-lightbox-media_video');
+		addClass(frameEl, 'fs-lightbox-video');
+
+		setAttr(iframeEl, {
+			'frameborder': '0',
+			'seamless': 'seamless',
+			'allowfullscreen': '',
+			'allow': 'autoplay; encrypted-media',
+			'referrerpolicy': 'strict-origin-when-cross-origin',
+			'data-src': source,
+			'title': item.caption || 'Lightbox Video',
+		});
+
+		frameEl.append(iframeEl);
+		mediaEl.append(frameEl);
+		wrapEl.append(mediaEl);
+		itemEl.append(wrapEl);
+
+		this.#checkDetails(item, itemEl);
+
+		this.containerEl.append(itemEl);
+
+		item.el = itemEl;
+		item.mediaEl = mediaEl;
+	}
+
+	#drawIframe(item, index) {
+		let itemEl = element('div');
+		let wrapEl = element('div');
+		let mediaEl = element('div');
+		let frameEl = element('div');
+		let iframeEl = element('iframe');
+
+		addClass(itemEl, 'fs-lightbox-item', `fs-lightbox-item_${index}`);
+		addClass(wrapEl, 'fs-lightbox-wrap');
+		addClass(mediaEl, 'fs-lightbox-media', 'fs-lightbox-media_iframe');
+		addClass(frameEl, 'fs-lightbox-iframe');
+
+		setAttr(iframeEl, {
+			'frameborder': '0',
+			'seamless': 'seamless',
+			'data-src': item.source,
+			'title': item.caption || 'Lightbox iFrame',
+		});
+
+		frameEl.append(iframeEl);
+		mediaEl.append(frameEl);
+		wrapEl.append(mediaEl);
+		itemEl.append(wrapEl);
+
+		this.#checkDetails(item, itemEl);
+
+		this.containerEl.append(itemEl);
+
+		item.el = itemEl;
+		item.mediaEl = mediaEl;
+		item.frameEl = frameEl;
+	}
+
+	#drawElement(item, index) {
+		let itemEl = element('div');
+		let wrapEl = element('div');
+		let mediaEl = element('div');
+		let frameEl = element('div');
+
+		item.targetEl = select(item.hash)[0];
+
+		addClass(itemEl, 'fs-lightbox-item', `fs-lightbox-item_${index}`, 'fs-lightbox-loaded');
+		addClass(wrapEl, 'fs-lightbox-wrap');
+		addClass(mediaEl, 'fs-lightbox-media', 'fs-lightbox-media_element');
+		addClass(frameEl, 'fs-lightbox-element');
+
+		frameEl.append(...item.targetEl.childNodes);
+		mediaEl.append(frameEl);
+		wrapEl.append(mediaEl);
+		itemEl.append(wrapEl);
+
+		this.#checkDetails(item, itemEl);
+
+		this.containerEl.append(itemEl);
+
+		item.isLoaded = true;
+
+		item.el = itemEl;
+		item.mediaEl = mediaEl;
+		item.frameEl = frameEl;
+
+		// on(select('.fs-lightbox-previous', item.el), 'click', () => {
+		//   console.log(this);
+		// });
+		// on(select('.fs-lightbox-next', item.el), 'click', this.listeners.next);
+	}
+
+	//
+
+	#setPositions() {
+		iterate(this.items, (item, index) => {
+			removeClass(item.el, 'fs-lightbox-active', 'fs-lightbox-item_previous', 'fs-lightbox-item_next');
+
+			if (index === this.index) {
+				addClass(item.el, 'fs-lightbox-active');
+
+				item.el.inert = false;
+
+				if (!item.isLoaded) {
+					this.#showLoading();
+
+					this.#loadItem(item, index);
+				} else {
+					this.#hideLoading();
+				}
+
+				this.#updateStatus();
+			} else {
+				once(item.el, 'transitionend', (e) => {
+					this.#unloadItem(item, index);
+				});
+
+				item.el.inert = true;
+			}
+
+			if (this.loop && this.index == this.maxIndex && index == 0) {
+				addClass(item.el, 'fs-lightbox-item_next');
+			} else if (this.loop && this.index == 0 && index == this.maxIndex) {
+				addClass(item.el, 'fs-lightbox-item_previous');
+			} else if (index < this.index) {
+				addClass(item.el, 'fs-lightbox-item_previous');
+			} else if (index > this.index) {
+				addClass(item.el, 'fs-lightbox-item_next');
+			}
+		});
+
+		if (!this.loop) {
+			setAttr(this.controlPreviousEl, 'disabled', (this.index === 0));
+			setAttr(this.controlNextEl, 'disabled', (this.index === this.maxIndex));
+		}
+	}
+
+	//
+
+	#loadItem(item, index) {
+		if (index !== this.index) {
+			return;
+		}
+
+		let media = select('[data-src]', item.el);
+
+		iterate(media, (m) => {
+			once(m, 'load', (e) => {
+				addClass(item.el, 'fs-lightbox-loaded');
+
+				item.isLoaded = true;
+
+				this.#hideLoading();
+			});
+
+			m.src = getAttr(m, 'data-src');
+		});
+	}
+
+	#unloadItem(item, index) {
+		if (index == this.index) {
+			return;
+		}
+
+		// if (item.isImage) {
+		//   this.#resetZoom(item);
+		// }
+
+		if ((item.isVideo || item.isIframe) && item.isLoaded) {
+			let media = select('[data-src]', item.el);
+
+			iterate(media, (m) => {
+				m.src = '';
+			});
+
+			removeClass(item.el, 'fs-lightbox-loaded');
+
+			item.isLoaded = false;
+		}
+	}
+
+	//
+
+	#hideLoading() {
+		removeClass(this.loadingEl, 'fs-lightbox-visible');
+		setAttr(this.loadingEl, 'aria-hidden', 'true');
+		setAttr(this.lightboxEl, 'aria-busy', 'false');
+	}
+
+	#showLoading() {
+		addClass(this.loadingEl, 'fs-lightbox-visible');
+		removeAttr(this.loadingEl, 'aria-hidden');
+		setAttr(this.lightboxEl, 'aria-busy', 'true');
+	}
+
+	//
+
+	#hideSiblings() {
+		updateAttr(siblings(this.lightboxEl), 'aria-hidden', 'true', 'lightbox');
+	}
+
+	#showSiblings() {
+		restoreAttr(siblings(this.lightboxEl), 'aria-hidden', 'lightbox');
+	}
+
+	//
+
+	#checkIndex() {
+		if (this.index < 0) {
+			this.index = this.loop ? this.maxIndex : 0;
+		}
+		if (this.index >= this.items.length) {
+			this.index = this.loop ? 0 : this.maxIndex;
+		}
+	}
+
+	#checkImage(source) {
+		return (source.match(this.fileTypes) !== null || source.substr(0, 10) === 'data:image');
+	}
+
+	#checkVideo(source) {
+		for (let i in this.videoProviders) {
+			let provider = this.videoProviders[i];
+			let parts = source.match(provider.pattern);
+
+			if (parts !== null) {
+				return provider.format.call(this, parts);
+			}
+		}
+
+		return false;
+	}
+
+	#checkDetails(item, el) {
+		let details = '';
+
+		if (this.items.length > 1 && this.ordinal) {
+			let ordinal = this.templates.ordinal
+				.replace('[current]', item.index + 1)
+				.replace('[total]', this.items.length);
+
+			details += `<div class="fs-lightbox-ordinal">${ordinal}</div>`;
+		}
+
+		if (item.caption) {
+			details += `<div class="fs-lightbox-caption">${item.caption}</div>`;
+		}
+
+		if (details !== '') {
+			el.insertAdjacentHTML('beforeend', `<div class="fs-lightbox-details">${details}</div>`);
+		}
+	}
+
+	#updateStatus() {
+		if (this.statusEl) {
+			this.statusEl.textContent = `${this.label}: ${this.index + 1} of ${this.items.length}`;
+		}
+	}
+
+	//
+
+	#onClick(e) {
+		e.preventDefault();
+		e.stopPropagation();
+
+		this.Lightbox.open();
+	}
+
+	#onContainerClick() {
+		return (e) => {
+			let item = this.items[this.index].mediaEl;
+
+			if (e.target !== item && !item.contains(e.target)) {
+				this.close();
+			} else {
+				this.#checkClick(e);
+			}
+		};
+	}
+
+	#checkClick(e) {
+		if (hasClass(e.target, 'fs-lightbox-trigger-previous')) {
+			this.previous();
+		}
+		if (hasClass(e.target, 'fs-lightbox-trigger-next')) {
+			this.next();
+		}
+		if (hasClass(e.target, 'fs-lightbox-trigger-close')) {
+			this.close();
+		}
+	}
+
+	#onClose() {
+		return (e) => {
+			this.close();
+		};
+	}
+
+	#onPrevious() {
+		return (e) => {
+			this.previous();
+		};
+	}
+
+	#onNext() {
+		return (e) => {
+			this.next();
+		};
+	}
+
+	#onKeyDown() {
+		return (e) => {
+			if (e.key === 'ArrowLeft') {
+				if (this.isRTL) {
+					this.next();
+				} else {
+					this.previous();
+				}
+			}
+			if (e.key === 'ArrowRight') {
+				if (this.isRTL) {
+					this.previous();
+				} else {
+					this.next();
+				}
+			}
+			// if (e.key === 'Escape') {
+			// 	this.close();
+			// }
+		};
+	}
+
+	//
+
+	#onPointerDown() {
+		return (e) => {
+			if (
+				!hasClass(e.target, 'fs-lightbox-trigger-previous') &&
+				!hasClass(e.target, 'fs-lightbox-trigger-next') &&
+				!hasClass(e.target, 'fs-lightbox-trigger-close') &&
+				e.target.tagName !== 'A' // don't act on links
+			) {
+				this.isTouching = true;
+				this.pointerStartX = e.clientX;
+				this.pointerStartY = e.clientY;
+
+				this.containerEl.setPointerCapture(e.pointerId);
+
+				addClass(this.containerEl, 'fs-lightbox-touching');
+
+				on(this.containerEl, 'pointermove', this.listeners.pointermove);
+				on(this.containerEl, 'pointerup', this.listeners.pointerup);
+			}
+		}
+	}
+
+	#onPointerMove() {
+		return (e) => {
+			let item = this.items[this.index];
+
+			// if (item.zoomed) {
+			//   // handle pan
+			//   let diffX = -(this.pointerStartX - e.clientX);
+			//   let diffY = -(this.pointerStartY - e.clientY);
+
+
+			// } else {
+			let diff = -(this.pointerStartX - e.clientX);
+
+			item.el.style.transform = `translate3d(${diff}px, 0, 0)`;
+			// }
+		}
+	}
+
+	#onPointerUp() {
+		return (e) => {
+			let item = this.items[this.index];
+
+			removeClass(this.containerEl, 'fs-lightbox-touching');
+
+			off(this.containerEl, 'pointermove', this.listeners.pointermove);
+			off(this.containerEl, 'pointerup', this.listeners.pointerup);
+
+			// if (item.zoomed) {
+			//   // handle pan
+			// } else {
+			let diff = this.pointerStartX - e.clientX;
+
+			item.el.style.transform = null;
+
+			if (Math.abs(diff) > this.threshold) {
+				if (diff < 0) {
+					if (this.isRTL) {
+						this.next();
+					} else {
+						this.previous();
+					}
+				}
+				if (diff > 0) {
+					if (this.isRTL) {
+						this.previous();
+					} else {
+						this.next();
+					}
+				}
+			}
+			// }
+
+			this.isTouching = false;
+
+			once(this.containerEl, 'click', (e) => {
+				e.stopPropagation(); // prevent closing when swiping
+			}, true);
+		}
+	}
+
+	// //
+
+	// #onZoomIn() {
+	//   return (e) => {
+	//     e.stopPropagation();
+
+	//     console.log('Zoom in');
+
+	//     let item = this.items[this.index];
+
+	//     item.zoomed = true;
+
+	//     addClass(item.el, 'fs-lightbox-zoomed');
+
+	//     console.log(item, item.el);
+	//   }
+	// }
+
+	// #onZoomOut() {
+	//   return (e) => {
+	//     e.stopPropagation();
+
+	//     console.log('Zoom out');
+
+	//     let item = this.items[this.index];
+
+	//     this.#resetZoom(item);
+	//   }
+	// }
+
+	// #resetZoom(item) {
+	//   item.zoomed = false;
+
+	//   removeClass(item.el, 'fs-lightbox-zoomed');
+
+	//   // item.el.style.transform
   // }
 
 };

--- a/src/less/lightbox.less
+++ b/src/less/lightbox.less
@@ -23,466 +23,504 @@
 @fs-lightbox-button-color: #fff;
 
 .fs-lightbox {
-  --fs-lightbox-duration: @fs-lightbox-duration;
-  --fs-lightbox-timing: @fs-lightbox-timing;
+	--fs-lightbox-duration: @fs-lightbox-duration;
+	--fs-lightbox-timing: @fs-lightbox-timing;
+
+	--fs-lightbox-overlay-bg: @fs-lightbox-overlay-bg;
+
+	--fs-lightbox-loading-color: @fs-lightbox-loading-color;
+	--fs-lightbox-loading-size: @fs-lightbox-loading-size;
+	--fs-lightbox-loading-spread: @fs-lightbox-loading-spread;
+	--fs-lightbox-loading-duration: @fs-lightbox-loading-duration;
+
+	--fs-lightbox-item-duration: @fs-lightbox-item-duration;
+	--fs-lightbox-item-timing: @fs-lightbox-item-timing;
+
+	--fs-lightbox-details-bg: @fs-lightbox-details-bg;
+	--fs-lightbox-details-color: @fs-lightbox-details-color;
+	--fs-lightbox-details-font: @fs-lightbox-details-font;
+	--fs-lightbox-details-padding: @fs-lightbox-details-padding;
+	--fs-lightbox-details-gap: @fs-lightbox-details-gap;
+
+	--fs-lightbox-button-background: @fs-lightbox-button-background;
+	--fs-lightbox-button-color: @fs-lightbox-button-color;
+
+	@media (prefers-reduced-motion) {
+
+		& {
+			--fs-lightbox-duration: 0s;
+			--fs-lightbox-loading-duration: 0s;
+			--fs-lightbox-item-duration: 0s;
+		}
+	}
+
+	//
+
+	height: 100vh;
+	width: 100vw;
+	max-height: 100vh;
+	max-width: 100vw;
+
+	position: fixed;
+	inset: 0;
+
+	background: transparent;
+	border: none;
+	margin: 0;
+
+	opacity: 0;
+	overflow: hidden;
+	padding: 0;
+	transition:
+		display var(--fs-lightbox-duration) var(--fs-lightbox-timing) allow-discrete,
+		opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing),
+		overlay var(--fs-lightbox-duration) var(--fs-lightbox-timing) allow-discrete;
+
+	&[open] {
+		display: flex;
+	}
+
+	&,
+	& * {
+		box-sizing: border-box;
+	}
+
+	//
+
+	&-open {
+		opacity: 1;
+
+		@starting-style {
+			opacity: 0;
+		}
+	}
+
+	&::backdrop {
+		background: var(--fs-lightbox-overlay-bg);
+		opacity: 0;
+		transition:
+			display var(--fs-lightbox-duration) var(--fs-lightbox-timing) allow-discrete,
+			opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing),
+			overlay var(--fs-lightbox-duration) var(--fs-lightbox-timing) allow-discrete;
+	}
+
+	&-open::backdrop {
+		opacity: 1;
+
+		@starting-style {
+			opacity: 0;
+		}
+	}
+
+	//
+
+	&,
+	&-overlay {
+		position: fixed;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+	}
+
+	&-overlay {
+		z-index: 0;
 
-  --fs-lightbox-overlay-bg: @fs-lightbox-overlay-bg;
+		background: var(--fs-lightbox-overlay-bg);
+	}
 
-  --fs-lightbox-loading-color: @fs-lightbox-loading-color;
-  --fs-lightbox-loading-size: @fs-lightbox-loading-size;
-  --fs-lightbox-loading-spread: @fs-lightbox-loading-spread;
-  --fs-lightbox-loading-duration: @fs-lightbox-loading-duration;
+	//
 
-  --fs-lightbox-item-duration: @fs-lightbox-item-duration;
-  --fs-lightbox-item-timing: @fs-lightbox-item-timing;
+	&-sr {
+		width: 1px !important;
+		height: 1px !important;
 
-  --fs-lightbox-details-bg: @fs-lightbox-details-bg;
-  --fs-lightbox-details-color: @fs-lightbox-details-color;
-  --fs-lightbox-details-font: @fs-lightbox-details-font;
-  --fs-lightbox-details-padding: @fs-lightbox-details-padding;
-  --fs-lightbox-details-gap: @fs-lightbox-details-gap;
+		position: absolute !important;
 
-  --fs-lightbox-button-background: @fs-lightbox-button-background;
-  --fs-lightbox-button-color: @fs-lightbox-button-color;
+		border-width: 0 !important;
+		clip: rect(0, 0, 0, 0) !important;
+		margin: -1px !important;
+		overflow: hidden !important;
+		padding: 0 !important;
+		white-space: nowrap !important;
+	}
 
-  @media (prefers-reduced-motion) {
+	//
 
-    & {
-      --fs-lightbox-duration: 0s;
-      --fs-lightbox-loading-duration: 0s;
-      --fs-lightbox-item-duration: 0s;
-    }
-  }
+	&-container {
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		z-index: 1;
 
-  //
+		user-select: none;
+	}
 
-  height: 100vh;
-  width: 100vw;
+	&-container&-touching {
+		cursor: grabbing;
+	}
 
-  z-index: 999;
+	//
 
-  opacity: 0;
-  transition: opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing);
+	&-item {
+		position: absolute;
+		top: env(safe-area-inset-top, 0px);
+		right: env(safe-area-inset-right, 0px);
+		bottom: env(safe-area-inset-bottom, 0px);
+		left: env(safe-area-inset-left, 0px);
 
-  &,
-  & * {
-    box-sizing: border-box;
-  }
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
 
-  //
+		opacity: 0;
+		transition:
+			opacity var(--fs-lightbox-item-duration) var(--fs-lightbox-item-timing),
+			transform var(--fs-lightbox-item-duration) var(--fs-lightbox-item-timing);
+		transform: none;
 
-  &-open {
-    opacity: 1;
-  }
+		&_previous {
+			transform: translate(-100%, 0);
+		}
 
-  //
+		&_next {
+			transform: translate(100%, 0);
+		}
+	}
 
-  &,
-  &-overlay {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-  }
+	&-item&-active&-loaded {
+		opacity: 1;
+	}
 
-  &-overlay {
-    z-index: 0;
+	//
 
-    background: var(--fs-lightbox-overlay-bg);
-  }
+	&-rtl &-item {
 
-  //
+		&_previous {
+			transform: translate(100%, 0);
+		}
 
-  &-sr {
-    width: 1px !important;
-    height: 1px !important;
+		&_next {
+			transform: translate(-100%, 0);
+		}
+	}
 
-    position: absolute !important;
+	//
 
-    border-width: 0 !important;
-    clip: rect(0, 0, 0, 0) !important;
-    margin: -1px !important;
-    overflow: hidden !important;
-    padding: 0 !important;
-    white-space: nowrap !important;
-  }
+	// &-item&-zoomed img {
+	//   max-height: none;
+	//   max-width: none;
+	// }
 
-  //
+	&-container&-touching &-item {
+		transition: none;
+	}
 
-  &-container {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 1;
+	&-wrap {
+		max-height: 100%;
+		max-width: 100%;
 
-    user-select: none;
-  }
+		display: flex;
+		justify-content: center;
 
-  &-container&-touching {
-    cursor: grabbing;
-  }
+		position: relative;
+	}
 
-  //
+	//
 
-  &-item {
-    position: absolute;
-    top: env(safe-area-inset-top, 0px);
-    right: env(safe-area-inset-right, 0px);
-    bottom: env(safe-area-inset-bottom, 0px);
-    left: env(safe-area-inset-left, 0px);
+	&-media {
+		height: auto;
+		width: auto;
+		max-height: 100%;
+		max-width: 100%;
 
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
 
-    opacity: 0;
-    transition:
-      opacity var(--fs-lightbox-item-duration) var(--fs-lightbox-item-timing),
-      transform var(--fs-lightbox-item-duration) var(--fs-lightbox-item-timing);
-    transform: none;
+	&-media_video {
+		max-width: 1200px;
 
-    &_previous {
-      transform: translate(-100%, 0);
-    }
+		flex-grow: 1;
+	}
 
-    &_next {
-      transform: translate(100%, 0);
-    }
-  }
+	&-media_image {
 
-  &-item&-active&-loaded {
-    opacity: 1;
-  }
+		img {
+			height: auto;
+			width: auto;
 
-  //
+			min-width: 200px;
 
-  &-rtl &-item {
+			max-height: 100%;
+			max-width: 100%;
 
-    &_previous {
-      transform: translate(100%, 0);
-    }
+			border: none;
+			display: block;
+			margin: auto;
 
-    &_next {
-      transform: translate(-100%, 0);
-    }
-  }
+			user-select: none;
+			touch-action: none;
+		}
+	}
 
-  //
+	&-video {
+		position: relative;
 
-  // &-item&-zoomed img {
-  //   max-height: none;
-  //   max-width: none;
-  // }
+		width: 100%;
 
-  &-container&-touching &-item {
-    transition: none;
-  }
+		iframe {
+			aspect-ratio: 16 / 9;
 
-  &-wrap {
-    max-height: 100%;
-    max-width: 100%;
+			width: 100%;
 
-    display: flex;
-    justify-content: center;
+			background: #000;
+		}
+	}
 
-    position: relative;
-  }
+	&-iframe {
 
-  //
+		iframe {
+			height: calc(100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
+			width: calc(100vw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px));
 
-  &-media {
-    height: auto;
-    width: auto;
-    max-height: 100%;
-    max-width: 100%;
+			background: #000;
+		}
+	}
 
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
+	&-iframe &-close {
+		// background: var(--fs-lightbox-button-background);
+		// color: var(--fs-lightbox-button-color);
+	}
 
-  &-media_video {
-    max-width: 1200px;
+	&-element {
+		max-width: 100%;
+		max-height: 100%;
 
-    flex-grow: 1;
-  }
+		overflow: auto;
+	}
 
-  &-media_image {
+	//
 
-    img {
-      height: auto;
-      width: auto;
+	&-details {
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: var(--fs-lightbox-details-gap);
 
-      min-width: 200px;
+		position: absolute;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		z-index: 2;
 
-      max-height: 100%;
-      max-width: 100%;
+		background: linear-gradient(to bottom, transparent, var(--fs-lightbox-details-bg));
+		color: var(--fs-lightbox-details-color);
+		font: var(--fs-lightbox-details-font);
+		opacity: 0;
+		padding: var(--fs-lightbox-details-padding);
+		transition: opacity 0.001s var(--fs-lightbox-item-timing) 0s;
 
-      border: none;
-      display: block;
-      margin: auto;
+		pointer-events: none;
 
-      user-select: none;
-      touch-action: none;
-    }
-  }
+		* {
+			pointer-events: all;
+		}
+	}
 
-  &-video {
-    position: relative;
+	&-item&-active &-details {
+		opacity: 1;
+		transition-delay: var(--fs-lightbox-item-duration);
+		transition-duration: var(--fs-lightbox-item-duration);
+	}
 
-    width: 100%;
+	&-container&-touching &-item&-active &-details {
+		opacity: 0;
+		transition-delay: 0.001s;
+		transition-duration: 0s;
+	}
 
-    iframe {
-      aspect-ratio: 16 / 9;
+	//
 
-      width: 100%;
+	&-close {
+		display: flex;
+		align-items: center;
+		justify-content: center;
 
-      background: #000;
-    }
-  }
+		height: 40px;
+		width: 40px;
 
-  &-iframe {
+		position: absolute;
+		top: env(safe-area-inset-top, 0px);
+		right: env(safe-area-inset-right, 0px);
+		z-index: 2;
 
-    iframe {
-      height: calc(100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
-      width: calc(100vw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px));
+		appearance: none;
 
-      background: #000;
-    }
-  }
+		background: var(--fs-lightbox-button-background);
+		border: none;
+		color: var(--fs-lightbox-button-color);
+		cursor: pointer;
+		padding: 0;
 
-  &-iframe &-close {
-    // background: var(--fs-lightbox-button-background);
-    // color: var(--fs-lightbox-button-color);
-  }
+		svg {
+			width: 30px;
+		}
+	}
 
-  &-element {
-    max-width: 100%;
-    max-height: 100%;
+	//
 
-    overflow: auto;
-  }
+	&:not(&-gallery) &-control {
+		display: none;
+	}
 
-  //
+	&-control {
+		display: flex;
+		align-items: center;
+		justify-content: center;
 
-  &-details {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--fs-lightbox-details-gap);
+		height: 40px;
+		width: 40px;
 
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 2;
+		position: absolute;
+		top: env(safe-area-inset-top, 0px);
+		bottom: env(safe-area-inset-bottom, 0px);
+		z-index: 2;
 
-    background: linear-gradient(to bottom, transparent, var(--fs-lightbox-details-bg));
-    color: var(--fs-lightbox-details-color);
-    font: var(--fs-lightbox-details-font);
-    opacity: 0;
-    padding: var(--fs-lightbox-details-padding);
-    transition: opacity 0.001s var(--fs-lightbox-item-timing) 0s;
+		appearance: none;
 
-    pointer-events: none;
+		background: var(--fs-lightbox-button-background);
+		border: none;
+		color: var(--fs-lightbox-button-color);
+		margin: auto;
+		padding: 0;
+		opacity: 0.5;
+		transition: opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing);
 
-    * {
-      pointer-events: all;
-    }
-  }
+		@media screen and (max-width: @fs-lightbox-mobile-max-width) {
+			top: auto;
+		}
 
-  &-item&-active &-details {
-    opacity: 1;
-    transition-delay: var(--fs-lightbox-item-duration);
-    transition-duration: var(--fs-lightbox-item-duration);
-  }
+		&_previous {
+			left: 0;
+		}
 
-  &-container&-touching &-item&-active &-details {
-    opacity: 0;
-    transition-delay: 0.001s;
-    transition-duration: 0s;
-  }
+		&_next {
+			right: 0;
+		}
 
-  //
+		svg {
+			width: 28px;
+		}
+	}
 
-  &-close {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+	//
 
-    height: 40px;
-    width: 40px;
+	&-rtl &-control {
 
-    position: absolute;
-    top: env(safe-area-inset-top, 0px);
-    right: env(safe-area-inset-right, 0px);
-    z-index: 2;
+		svg {
+			transform: scale(-1);
+		}
 
-    appearance: none;
+		&_previous {
+			left: unset;
+			right: 0;
+		}
 
-    background: var(--fs-lightbox-button-background);
-    border: none;
-    color: var(--fs-lightbox-button-color);
-    cursor: pointer;
-    padding: 0;
+		&_next {
+			right: unset;
+			left: 0;
+		}
+	}
 
-    svg {
-      width: 30px;
-    }
-  }
+	//
 
-  //
+	&-control:not([disabled]) {
+		cursor: pointer;
+		opacity: 1;
+	}
 
-  &:not(&-gallery) &-control {
-    display: none;
-  }
+	//
 
-  &-control {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+	// &-zoom {
+	//   display: flex;
+	//   align-items: center;
+	//   justify-content: center;
 
-    height: 40px;
-    width: 40px;
+	//   height: 40px;
+	//   width: 40px;
 
-    position: absolute;
-    top: env(safe-area-inset-top, 0px);
-    bottom: env(safe-area-inset-bottom, 0px);
-    z-index: 2;
+	//   position: absolute;
+	//   bottom: env(safe-area-inset-bottom, 0px);
+	//   right: env(safe-area-inset-right, 0px);
+	//   z-index: 2;
 
-    appearance: none;
+	//   appearance: none;
 
-    background: var(--fs-lightbox-button-background);
-    border: none;
-    color: var(--fs-lightbox-button-color);
-    margin: auto;
-    padding: 0;
-    opacity: 0.5;
-    transition: opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing);
+	//   background: var(--fs-lightbox-button-background);
+	//   border: none;
+	//   color: var(--fs-lightbox-button-color);
+	//   display: none;
+	//   margin: auto;
+	//   padding: 0;
+	//   // opacity: 0.5;
+	//   // transition: opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing);
 
-    @media screen and (max-width: @fs-lightbox-mobile-max-width) {
-      top: auto;
-    }
+	//   &_in {
+	//     right: calc(env(safe-area-inset-right, 0px) + 40px);
 
-    &_previous {
-      left: 0;
-    }
+	//     display: block;
+	//   }
 
-    &_next {
-      right: 0;
-    }
+	//   &_out {
+	//     display: block;
+	//   }
 
-    svg {
-      width: 28px;
-    }
-  }
+	//   svg {
+	//     width: 28px;
+	//   }
+	// }
 
-  //
+	//
 
-  &-rtl &-control {
+	&-loading {
+		display: flex;
+		justify-content: center;
+		align-items: center;
 
-    svg {
-      transform: scale(-1);
-    }
+		height: var(--fs-lightbox-loading-size);
+		width: var(--fs-lightbox-loading-size);
 
-    &_previous {
-      left: unset;
-      right: 0;
-    }
+		position: fixed;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
 
-    &_next {
-      right: unset;
-      left: 0;
-    }
-  }
+		animation: fs-lightbox-loading-spin var(--fs-lightbox-loading-duration) linear infinite;
+		border: var(--fs-lightbox-loading-spread) solid transparent;
+		border-top-color: var(--fs-lightbox-loading-color);
+		border-radius: 100%;
+		margin: auto;
+		opacity: 0;
+		transition: opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing);
+	}
 
-  //
-
-  &-control:not([disabled]) {
-    cursor: pointer;
-    opacity: 1;
-  }
-
-  //
-
-  // &-zoom {
-  //   display: flex;
-  //   align-items: center;
-  //   justify-content: center;
-
-  //   height: 40px;
-  //   width: 40px;
-
-  //   position: absolute;
-  //   bottom: env(safe-area-inset-bottom, 0px);
-  //   right: env(safe-area-inset-right, 0px);
-  //   z-index: 2;
-
-  //   appearance: none;
-
-  //   background: var(--fs-lightbox-button-background);
-  //   border: none;
-  //   color: var(--fs-lightbox-button-color);
-  //   display: none;
-  //   margin: auto;
-  //   padding: 0;
-  //   // opacity: 0.5;
-  //   // transition: opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing);
-
-  //   &_in {
-  //     right: calc(env(safe-area-inset-right, 0px) + 40px);
-
-  //     display: block;
-  //   }
-
-  //   &_out {
-  //     display: block;
-  //   }
-
-  //   svg {
-  //     width: 28px;
-  //   }
-  // }
-
-  //
-
-  &-loading {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    height: var(--fs-lightbox-loading-size);
-    width: var(--fs-lightbox-loading-size);
-
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-
-    animation: fs-lightbox-loading-spin var(--fs-lightbox-loading-duration) linear infinite;
-    border: var(--fs-lightbox-loading-spread) solid transparent;
-    border-top-color: var(--fs-lightbox-loading-color);
-    border-radius: 100%;
-    margin: auto;
-    opacity: 0;
-    transition: opacity var(--fs-lightbox-duration) var(--fs-lightbox-timing);
-  }
-
-  &-loading&-visible {
-    opacity: 1;
-  }
+	&-loading&-visible {
+		opacity: 1;
+	}
 }
 
 @keyframes fs-lightbox-loading-spin {
 
-  from {
-    transform: rotate(0deg);
-  }
+	from {
+		transform: rotate(0deg);
+	}
 
-  to {
-    transform: rotate(360deg);
-  }
+	to {
+		transform: rotate(360deg);
+	}
 }
+


### PR DESCRIPTION
# Accessibility
Refactor the Lightbox component to use native browser features for modal.

* Replaced the generic `div` container with a native `<dialog>` element.
* Use the native `autofocus` attribute on the close button to ensure immediate focus upon opening.
* Switched from manual visibility toggling to `showModal()` and `close()` methods. `showModal()` displays modal on the browser's "top layer" which means we don't need to mess with `z-index`. We get a lot of features for free when using `showModal` API; focus trapping, focus return to trigger, close with escape, etc...
* Add `label` setting to apply an accessible label to the <dialog> element via the `aria-label` attribute. An accessible label is mandatory here but it wouldn't be good if the same label was used multiple times per page. Tough one to know what to do but definitely need a way to set it.
* Triggers now automatically receive `role="button"` and `aria-haspopup="dialog"`.
* Automatically generate trigger labels from `lightboxCaption` or image `alt` text if no label is provided.
* Added a status region (`fs-lightbox-status`) with `aria-live="polite"` to announce gallery progress ("Gallery: 1 of 5") to screen reader users.
* Added `aria-busy` on the lightbox container to signal loading states.
* Items in a gallery now use the `inert` property when not active to prevent focus of off-screen content.